### PR TITLE
Proxy requests synchronously

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -39,9 +39,9 @@ func (p *SprayProxy) HandleProxy(c *gin.Context) {
 		}
 		copy := c.Copy()
 		// Create a new request with a disconnected context
-		newRequest := copy.Request.WithContext(context.Background())
+		newRequest := copy.Request.Clone(context.Background())
 		proxy := httputil.NewSingleHostReverseProxy(url)
-		go doProxy(backend, proxy, newRequest)
+		doProxy(backend, proxy, newRequest)
 	}
 	c.String(http.StatusOK, "proxied")
 }


### PR DESCRIPTION
Proxy requests to backends in a synchronous fashion. This prevents errors in the backend reading from a "closed" request body.