### PR TITLE
Handle root GET

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,6 +27,7 @@ func NewServer(host string, port int, backends ...string) (*SprayProxyServer, er
 		return nil, err
 	}
 	r := gin.Default()
+	r.GET("/", handleHealthz)
 	r.POST("/", sprayProxy.HandleProxy)
 	r.GET("/healthz", handleHealthz)
 	return &SprayProxyServer{


### PR DESCRIPTION
Use the healthz handler to respond to root GET requests.