### PR TITLE
Add insecure tls

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ You can also configure the proxy with environment variables:
   ```
   SPRAYPROXY_SERVER_BACKENDS="http://localhost:8080 http://localhost:8081"
   ```
+* `SPRAYPROXY_SERVER_INSECURE_SKIP_TLS_VERIFY`: Skip TLS verification when forwarding to backends.
+  **Note: this setting is insecure and should not be used in production environments.**
 
 ## Developing
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -26,7 +26,8 @@ sprayproxy server --backend http://localhost:8081 --backend http://localhost:808
 		host := viper.GetString("host")
 		port := viper.GetInt("port")
 		backends := viper.GetStringSlice("backends")
-		server, err := server.NewServer(host, port, backends...)
+		insecureSkipTLSVerify := viper.GetBool("insecure-skip-tls-verify")
+		server, err := server.NewServer(host, port, insecureSkipTLSVerify, backends...)
 		if err != nil {
 			return err
 		}
@@ -54,6 +55,8 @@ func init() {
 	serverCmd.Flags().String("host", "", "Host for running the server. Defaults to localhost")
 	serverCmd.Flags().Int("port", 8080, "Port for running the server. Defaults to 8080")
 	serverCmd.Flags().StringSlice("backend", []string{}, "Backend to forward requests. Use more than once.")
+	serverCmd.Flags().Bool("insecure-skip-tls-verify", false, "Skip TLS verification on all backends. INSECURE - do not use in production.")
 
 	viper.BindPFlags(serverCmd.Flags())
+
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestHandleProxy(t *testing.T) {
-	proxy, err := NewSprayProxy()
+	proxy, err := NewSprayProxy(false)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -22,8 +22,8 @@ type SprayProxyServer struct {
 	port   int
 }
 
-func NewServer(host string, port int, backends ...string) (*SprayProxyServer, error) {
-	sprayProxy, err := proxy.NewSprayProxy(backends...)
+func NewServer(host string, port int, insecureSkipTLS bool, backends ...string) (*SprayProxyServer, error) {
+	sprayProxy, err := proxy.NewSprayProxy(insecureSkipTLS, backends...)
 	if err != nil {
 		return nil, err
 	}
@@ -44,6 +44,9 @@ func (s *SprayProxyServer) Run() error {
 	address := fmt.Sprintf("%s:%d", s.host, s.port)
 	fmt.Printf("Running spray proxy on %s\n", address)
 	fmt.Printf("Forwarding traffic to %s\n", strings.Join(s.proxy.Backends(), ","))
+	if s.proxy.InsecureSkipTLSVerify() {
+		fmt.Printf("WARNING: Skipping TLS verification on backends.")
+	}
 	return s.server.Run(address)
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestServerRootPost(t *testing.T) {
-	server, err := NewServer("localhost", 8080)
+	server, err := NewServer("localhost", 8080, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestServerRootPost(t *testing.T) {
 }
 
 func TestServerHealthz(t *testing.T) {
-	server, err := NewServer("localhost", 8080)
+	server, err := NewServer("localhost", 8080, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Support skipping TLS verification on backends. This should be used for testing purposes only, and not in production enviornments.