### PR TITLE
Use underscores for flag keys

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -24,6 +24,8 @@ spec:
             value: $(params.repo_url)
           - name: revision
             value: $(params.revision)
+          - name: deleteExisting
+            value: "false"
         taskRef:
           kind: ClusterTask
           name: git-clone

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -51,6 +53,8 @@ func init() {
 	viper.SetDefault("port", 8080)
 
 	viper.SetEnvPrefix("SPRAYPROXY_SERVER")
+	// Replace "-" with underscores "_"
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	serverCmd.Flags().String("host", "", "Host for running the server. Defaults to localhost")
 	serverCmd.Flags().Int("port", 8080, "Port for running the server. Defaults to 8080")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -45,7 +45,7 @@ func (s *SprayProxyServer) Run() error {
 	fmt.Printf("Running spray proxy on %s\n", address)
 	fmt.Printf("Forwarding traffic to %s\n", strings.Join(s.proxy.Backends(), ","))
 	if s.proxy.InsecureSkipTLSVerify() {
-		fmt.Printf("WARNING: Skipping TLS verification on backends.")
+		fmt.Printf("WARNING: Skipping TLS verification on backends.\n")
 	}
 	return s.server.Run(address)
 }


### PR DESCRIPTION
Fix issue where viper wasn't using underscores when mapping flags to config options.