### PR TITLE
PLNSRVCE-1022: prepare sprayproxy for stonesoup use of kube-rbac-proxy

### DIFF
--- a/config/namespace.yaml
+++ b/config/namespace.yaml
@@ -5,3 +5,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-sprayproxy
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/config/rbac/auth-proxy-client-clusterrole.yaml
+++ b/config/rbac/auth-proxy-client-clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sprayproxy-metrics-reader
+rules:
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-proxy-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-proxy-role
+subjects:
+  - kind: ServiceAccount
+    name: redhat-sprayproxy
+    namespace: redhat-sprayproxy

--- a/config/sprayproxy.yaml
+++ b/config/sprayproxy.yaml
@@ -29,12 +29,28 @@ spec:
           ports:
             - containerPort: 8080
               name: server
-            - containerPort: 6000
-              name: metrics
           resources:
             limits:
               memory: "128Mi"
               cpu: "500m"
+        - name: kube-rbac-proxy
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:6000/"
+            - "--logtostderr=true"
+            - "--v=0"
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+              name: https
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
 ---
 apiVersion: v1
 kind: Service
@@ -48,6 +64,17 @@ spec:
     - name: server
       protocol: TCP
       port: 8080
-    - name: metric
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sprayproxy-metrics-service
+  namespace: redhat-sprayproxy
+spec:
+  selector:
+    app.kubernetes.io/name: sprayproxy
+  ports:
+    - name: https
       protocol: TCP
-      port: 6000
+      port: 8443
+      targetPort: https


### PR DESCRIPTION
The cluster role here stems from the conversation @gbenhaim @bamachrn and my self had

The associated `ClusterRoleBinding` per established convention will be defined in infra-deployments.  I'll make that update there, citing the commit sha from this merged PR.

@bamachrn - when looking at some of the existing example like the build-service, I noticed they also had 
- https://github.com/redhat-appstudio/build-service/blob/main/config/rbac/auth_proxy_role.yaml
- https://github.com/redhat-appstudio/build-service/blob/main/config/rbac/auth_proxy_role_binding.yaml
- https://github.com/redhat-appstudio/build-service/blob/main/config/rbac/auth_proxy_service.yaml

Based on the PR and commit they came from, I suspect `kubebuilder` created those for build-service when they initially boostrapped the repo, and have just been always included.

Now, since these did not come up in our call, I've refrained from adding them here.  But please advise if you think we just mistakenly omitted talking about these during our call.

Lastly, @adambkaplan - I also took the liberty of adding a label to the namespace which enables the OCP dev console's monitoring panel from being able to see sprayproxy stats.  I did this just for our testing convenience.  But certainly let me know if you would rather I did not do that.