### PR TITLE
Log forwarding requests

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"log"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -9,10 +10,17 @@ import (
 
 func Get() *zap.Logger {
 	config := zap.NewProductionConfig()
-	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	config.DisableStacktrace = true
+	config.InitialFields = map[string]any{"service": "sprayproxy"}
+	config.EncoderConfig.EncodeTime = utcRFC3339TimeEncoder
 	logger, err := config.Build()
 	if err != nil {
 		log.Fatalf("Failed to initialize zap logger: %v", err)
 	}
 	return logger
+}
+
+// custom encoder to log timestamp in UTC
+func utcRFC3339TimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	zapcore.RFC3339TimeEncoder(t.UTC(), enc)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	ginzap "github.com/gin-contrib/zap"
 	"github.com/gin-gonic/gin"
@@ -33,7 +32,7 @@ func init() {
 }
 
 func NewServer(host string, port int, insecureSkipTLS bool, backends ...string) (*SprayProxyServer, error) {
-	sprayProxy, err := proxy.NewSprayProxy(insecureSkipTLS, backends...)
+	sprayProxy, err := proxy.NewSprayProxy(insecureSkipTLS, zapLogger, backends...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +40,7 @@ func NewServer(host string, port int, insecureSkipTLS bool, backends ...string) 
 	//gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	// setting middleware before routes, otherwise it does not work (gin bug)
-	r.Use(ginzap.Ginzap(zapLogger, time.RFC3339, true))
+	r.Use(ginzap.GinzapWithConfig(zapLogger, &ginzap.Config{}))
 	r.Use(ginzap.RecoveryWithZap(zapLogger, true))
 	r.GET("/", handleHealthz)
 	r.POST("/", sprayProxy.HandleProxy)


### PR DESCRIPTION
Add logging to the proxy package. Using the same logger as the server passed as a parameter, so logs are kept in sync and buffer flushed on exit.
Note: The forwarding entry precedes the server access log entry as the latter is only logged on handler return.
Changed zap config to only log one timestamp in UTC.