### PR TITLE
STONEBLD-777 - tekton-ci: update bundle

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -16,7 +16,7 @@ spec:
       value: "quay.io/redhat-appstudio/pull-request-builds:sprayproxy-{{revision}}"
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -16,7 +16,7 @@ spec:
       value: "quay.io/redhat-appstudio/sprayproxy:{{revision}}"
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/unit-test.yaml
+++ b/.tekton/unit-test.yaml
@@ -28,7 +28,7 @@ spec:
     tasks:
       - name: fetch-repository
         taskRef:
-          bundle: quay.io/redhat-appstudio/appstudio-tasks:748a03507b68aa610212e8031e3301ab943a14ef-1
+          bundle: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1
           name: git-clone
         workspaces:
           - name: output


### PR DESCRIPTION
Switching to new bundle since development of old one was stopped before attempt to migrate to kcp. New bundle is removing dependency on shared secret.