### PR TITLE
Use HSTS header for sprayproxy api route.

### DIFF
--- a/config/route.yaml
+++ b/config/route.yaml
@@ -6,6 +6,8 @@ kind: Route
 metadata:
   name: sprayproxy-route
   namespace: sprayproxy
+  annotations:
+    haproxy.router.openshift.io/hsts_header: "max-age=63072000"
 spec:
   tls:
     termination: edge


### PR DESCRIPTION
Use HSTS header for sprayproxy api route. This option should include HSTS (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header to response.