### PR TITLE
fix tls redirect termination unknown field

### DIFF
--- a/config/route.yaml
+++ b/config/route.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   tls:
     termination: edge
-    insecureEdgeTermination: Redirect
+    insecureEdgeTerminationPolicy: Redirect
   to:
     kind: Service
     name: sprayproxy-service


### PR DESCRIPTION
Typo fix

The existing field throws error
```
$ oc apply -f ./config/route.yaml
W0413 20:17:10.265622   63797 warnings.go:70] unknown field "spec.tls.insecureEdgeTermination"
```

Signed-off-by: Priti Kumari [pkumari@redhat.com](mailto:pkumari@redhat.com)