### PR TITLE
PLNSRVCE-1108: update infra-deployment push to update staging (and only staging)

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -14,6 +14,9 @@ spec:
       value: "{{revision}}"
     - name: output-image
       value: "quay.io/redhat-appstudio/sprayproxy:{{revision}}"
+    - name: infra-deployment-update-script
+      value: |
+        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/sprayproxy/staging/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest


### PR DESCRIPTION
So this PR should do 2 things:
1) ensure this job updates the "atypical" path in infra-deployments we have for spray proxy
2) with the new "definition of done" process from recent arch meetings, we update staging only with such promotions, and then only update prod when we are satisfied with how the change has done in staging

Longer term, there are various automation initiatives that could follow on this (including, but not exclusively to, the bump of prod based on these changes to staging).

@adambkaplan @avinal (who submitted the original push def here) @prietyc123 (who has offered cycles around further automation)