### PR TITLE
follow ADR-6 convention for logs

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -11,7 +11,7 @@ import (
 func Get() *zap.Logger {
 	config := zap.NewProductionConfig()
 	config.DisableStacktrace = true
-	config.InitialFields = map[string]any{"service": "sprayproxy"}
+	config.InitialFields = map[string]any{"service": "sprayproxy", "audit": "true"}
 	config.EncoderConfig.EncodeTime = utcRFC3339TimeEncoder
 	logger, err := config.Build()
 	if err != nil {


### PR DESCRIPTION
This PR adds:
    - add key-value `"audit":"true"` to the root of the logs generated
      by the spray-proxy logger

Example logs with `"audit":"true` values.

```
{"level":"info","ts":"2023-04-26T10:43:50Z","caller":"proxy/proxy.go:112","msg":"proxied request","audit":true,"method":"POST","path":"/","query":"","insecure-tls":false,"request-id":"7424cc93-44c2-421c-9e04-4d95def75010","backend":"localhost:8095","latency":0.000637977,"status":200}
{"level":"info","ts":"2023-04-26T10:43:50Z","caller":"zap/zap.go:90","msg":"/","audit":true,"status":200,"method":"POST","path":"/","query":"","ip":"127.0.0.1","user-agent":"curl/7.85.0","latency":0.000724511,"request-id":"7424cc93-44c2-421c-9e04-4d95def75010"}
```