### PR TITLE
Add forwarding request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ SPRAYPROXY_SERVER_BACKEND="http://localhost:8080 http://localhost:8081"
 * `SPRAYPROXY_SERVER_INSECURE_SKIP_TLS_VERIFY`: Skip TLS verification when forwarding to backends.
   **Note: this setting is insecure and should not be used in production environments.**
 
+Other configuration options:
+
+* `SPRAYPROXY_FORWARDING_REQUEST_TIMEOUT`: override the default forwarding request timeout.
+
 ## Developing
 
 * Run `make build` to build the proxy sever (output to `bin/sprayproxy`)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -18,6 +18,45 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+func TestProxyDefaultTimeoutNoEnv(t *testing.T) {
+	proxy, err := NewSprayProxy(false, zap.NewNop())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	expectedTmout := "15s"
+	gotTmout := proxy.fwdReqTmout.String()
+	if expectedTmout != gotTmout {
+		t.Errorf("expected timeout %q, got %q", expectedTmout, gotTmout)
+	}
+}
+
+func TestProxyDefaultTimeoutBadEnv(t *testing.T) {
+	// "foo" is not a time.Duration value and should be ignored
+	t.Setenv("SPRAYPROXY_FORWARDING_REQUEST_TIMEOUT", "foo")
+	proxy, err := NewSprayProxy(false, zap.NewNop())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	expectedTmout := "15s"
+	gotTmout := proxy.fwdReqTmout.String()
+	if expectedTmout != gotTmout {
+		t.Errorf("expected timeout %q, got %q", expectedTmout, gotTmout)
+	}
+}
+
+func TestProxyCustomTimeout(t *testing.T) {
+	t.Setenv("SPRAYPROXY_FORWARDING_REQUEST_TIMEOUT", "90s")
+	proxy, err := NewSprayProxy(false, zap.NewNop())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	expectedTmout := "1m30s"
+	gotTmout := proxy.fwdReqTmout.String()
+	if expectedTmout != gotTmout {
+		t.Errorf("expected timeout %q, got %q", expectedTmout, gotTmout)
+	}
+}
+
 func TestHandleProxy(t *testing.T) {
 	proxy, err := NewSprayProxy(false, zap.NewNop())
 	if err != nil {


### PR DESCRIPTION
Based on http.Client.Timeout the timeout covers the end to end handling of the forwarded request (from the connection Dial till the response body is received from the backend). 
The default timeout can be overridden by setting the SPRAYPROXY_FORWARDING_REQUEST_TIMEOUT env var to value compatible with time.Duration e.g 20s, 1m etc.