### PR TITLE
Add test for forwarded request body

### DIFF
--- a/test/backend.go
+++ b/test/backend.go
@@ -12,8 +12,9 @@ import (
 )
 
 type testBackend struct {
-	server *httptest.Server
-	err    error
+	server  *httptest.Server
+	reqBody string
+	err     error
 }
 
 func (b *testBackend) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
@@ -25,6 +26,7 @@ func (b *testBackend) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	b.reqBody = buf.String()
 	rw.WriteHeader(http.StatusOK)
 }
 
@@ -34,6 +36,10 @@ func (b *testBackend) GetServer() *httptest.Server {
 
 func (b *testBackend) GetError() error {
 	return b.err
+}
+
+func (b *testBackend) GetReqBody() string {
+	return b.reqBody
 }
 
 func NewTestServer() *testBackend {


### PR DESCRIPTION
http.Request.Body can only be read once. The next time it is read, an empty body is returned without indication of an error. Sprayproxy does multiple checks on the request body and for each one the body is read. More checks can be added in the future. The added test verifies the original request body is preserved and forwarded to the backend servers.