### PR TITLE
Fix test regression

### DIFF
--- a/test/e2e/e2e_server_test.go
+++ b/test/e2e/e2e_server_test.go
@@ -63,7 +63,7 @@ func TestBackendRequestBody(t *testing.T) {
 	defer backend1.GetServer().Close()
 	backend2 := test.NewTestServer()
 	defer backend2.GetServer().Close()
-	server, err := server.NewServer("localhost", 8080, false, backend1.GetServer().URL, backend2.GetServer().URL)
+	server, err := server.NewServer("localhost", 8080, false, true, backend1.GetServer().URL, backend2.GetServer().URL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
We got regression in tests as a result of two changes (one adding a test and another one changing a method signature) being merged without a rebase after the first one.