### PR TITLE
Bump sprayproxy memory limit

### DIFF
--- a/config/sprayproxy.yaml
+++ b/config/sprayproxy.yaml
@@ -31,7 +31,7 @@ spec:
               name: server
           resources:
             limits:
-              memory: "128Mi"
+              memory: "384Mi"
               cpu: "500m"
         - name: kube-rbac-proxy
           image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12


### PR DESCRIPTION
Given that sprayproxy manages requests which could be as large as 25MB and it reads those requests into memory before processing them, this allows us to handle multiple slow large request without hitting that limit.