### PR TITLE
Change metrics port

### DIFF
--- a/config/sprayproxy.yaml
+++ b/config/sprayproxy.yaml
@@ -68,7 +68,7 @@ spec:
           image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
           args:
             - "--secure-listen-address=0.0.0.0:9443"
-            - "--upstream=http://127.0.0.1:6000/"
+            - "--upstream=http://127.0.0.1:9090/"
             - "--logtostderr=true"
             - "--v=4"
           ports:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,7 +21,7 @@ const (
 	forwardedResponseTimeName = subsystem + separator + responseTime + separator + "duration_seconds"
 	hostLabel                 = "host"
 
-	MetricsPort = 6000
+	MetricsPort = 9090
 )
 
 var (

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -81,7 +81,7 @@ func NewServer(host string, port int, insecureSkipTLS, insecureSkipWebhookVerify
 // Run launches the proxy server with the pre-configured hostname and address.
 func (s *SprayProxyServer) Run() error {
 	address := fmt.Sprintf("%s:%d", s.host, s.port)
-	zapLogger.Info(fmt.Sprintf("Running spray proxy on %s", address))
+	zapLogger.Info(fmt.Sprintf("Running sprayproxy on %s", address))
 	zapLogger.Info(fmt.Sprintf("Forwarding traffic to %s", strings.Join(s.proxy.Backends(), ",")))
 	if s.proxy.InsecureSkipTLSVerify() {
 		zapLogger.Warn("Skipping TLS verification on backends")


### PR DESCRIPTION
Originally set to 6000, it's not convenient for local testing as Chrome
 blocks connections to that port with ERR_UNSAFE_PORT. It's possible to
override that, but the configuration is global.
No change on the service monitor will be required.

Update log entry to use the sprayproxy name.