### PR TITLE
Update metrics for forwarded requests

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,6 +20,7 @@ const (
 	responseTime              = prefix + separator + "response" + separator + "time"
 	forwardedResponseTimeName = subsystem + separator + responseTime + separator + "duration_seconds"
 	hostLabel                 = "host"
+	errorLabel                = "error"
 
 	MetricsPort = 9090
 )
@@ -55,7 +56,7 @@ func createMetrics() []prometheus.Collector {
 		Name: forwardedRequestsName,
 		Help: "Counts forwarded attempts to backend server(s).",
 	},
-		[]string{hostLabel})
+		[]string{hostLabel, errorLabel})
 	responseTimes = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: forwardedResponseTimeName,
 		Help: "Forwarded request duration in seconds.",
@@ -75,9 +76,12 @@ func IncInboundCount() {
 	}
 }
 
-func IncForwardedCount(hostname string) {
+func IncForwardedCount(hostname, fwdErr string) {
 	if forwardedRequests != nil {
-		forwardedRequests.With(prometheus.Labels{hostLabel: hostname}).Inc()
+		if fwdErr == "" {
+			fwdErr = "none"
+		}
+		forwardedRequests.With(prometheus.Labels{hostLabel: hostname, errorLabel: fwdErr}).Inc()
 	}
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -38,7 +38,7 @@ func TestMetrics(t *testing.T) {
 				`# TYPE ` + inboundRequestsName + ` counter`,
 				inboundRequestsName + ` 1`,
 				`# TYPE ` + forwardedRequestsName + ` counter`,
-				forwardedRequestsName + `{host="host1"} 2`,
+				forwardedRequestsName + `{error="none",host="host1"} 2`,
 				`# TYPE ` + forwardedResponseTimeName + ` histogram`,
 				forwardedResponseTimeName + `_sum 50`,
 				forwardedResponseTimeName + `_count 1`,
@@ -71,7 +71,7 @@ func TestMetrics(t *testing.T) {
 			IncInboundCount()
 		}
 		for i := 0; i < test.forwards; i += 1 {
-			IncForwardedCount("host1")
+			IncForwardedCount("host1", "")
 		}
 		if test.responseTime > 0 {
 			AddForwardedResponseTime(test.responseTime)

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -216,7 +216,7 @@ func TestMetricQueries(t *testing.T) {
 			IncInboundCount()
 		}
 		for i := 0; i < test.forwards; i += 1 {
-			IncForwardedCount("host")
+			IncForwardedCount("host", "")
 		}
 
 		port, ch := runMetricsServer(t)


### PR DESCRIPTION
Update metrics for forwarded request to account for the actual result. Counter will always be incremented regardless of the HTTP return code, but failure to speak HTTP (such as a network connectivity problem) won't be counted. Such failures will also not appear in the latency results.